### PR TITLE
Updated code to use the latest version of PyEnsign and added error handling for closed websocket connections

### DIFF
--- a/pypredict/trades.py
+++ b/pypredict/trades.py
@@ -60,7 +60,6 @@ class TradesPublisher:
                         for event in self.message_to_events(json.loads(message)):
                             await self.ensign.publish(self.topic, event, on_ack=handle_ack, on_nack=handle_nack)
             except websockets.exceptions.ConnectionClosedError as e:
-                # TODO: Make sure reconnect is happening for dropped connections.
                 logging.error(f"Websocket connection closed: {e}")
                 continue
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 jinja2
-pyensign>=0.7.1b1
+pyensign==0.10b0
 river==0.17.0
 uvicorn
 websockets


### PR DESCRIPTION
The trades app was deployed before changes were made to PyEnsign to support the generator syntax.  This PR updates the code to use the latest version of PyEnsign and ensures that the websocket connection is restored if the connection gets closed.  

Prior to the websocket connection fix, the app stopped running after encountering this error:

`Websocket connection closed: no close frame received or sent`

I ran the app overnight and was able to verify that it continues to run even after this error occurred.

@pdeziel  - could you also test this on your machine before re-deploying the app?  I had to downgrade river to version 0.15.0 due to the issue with the docker build on my machine.